### PR TITLE
Add phpunit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor/
 composer.lock
+.phpunit.result.*
+build/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ But at the same time you still WANT to implement **good practices** and **standa
     --standard The name or path of the coding standard. Defaults to PSR12.
 ```
 
+## Run tests
+```bash
+$ composer test
+```
+
 ### License
 
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ But at the same time you still WANT to implement **good practices** and **standa
 ```
 
 ## Run tests
-```bash
+```
 $ composer test
 ```
 

--- a/bin/super-giggle
+++ b/bin/super-giggle
@@ -19,10 +19,12 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php') === true) {
 use SuperGiggle\Main;
 use SuperGiggle\Util;
 
-$opts = Util::parseArgs();
+$util = new Util;
+$opts = $util->parseArgs();
 if (isset($opts['help'])) {
-    Util::printUsage();
+    $util->printUsage();
 }
 
 $phpcs = new Main();
+$phpcs->setUtil($util);
 $phpcs->run($opts);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,13 @@
 {
     "autoload": {
-        "psr-4": {"SuperGiggle\\": "src/"}
+        "psr-4": {
+            "SuperGiggle\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SuperGiggle\\": "tests/src/"
+        }
     },
     "name": "roger-sei/super-giggle",
     "description": "SuperGiggle checks the coding standards for a specific commit change",
@@ -11,5 +18,11 @@
     "license": "MIT",
     "bin": [
         "bin/super-giggle"
-    ]
+    ],
+    "require-dev": {
+        "phpunit/phpunit": "^8"
+    },
+    "scripts": {
+        "test": "phpunit --testdox --colors=always"
+    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="SupperGiggle Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage" lowUpperBound="35" highLowerBound="70"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/src/Main.php
+++ b/src/Main.php
@@ -16,8 +16,6 @@
 
 namespace SuperGiggle;
 
-use SuperGiggle\Util;
-
 class Main
 {
 
@@ -43,6 +41,13 @@ class Main
     private $options = [];
 
     /**
+     * Util class
+     *
+     * @var Util
+     */
+    private $util;
+
+    /**
      * Indicates whether it has found error or not.
      *
      * @var bool
@@ -65,6 +70,19 @@ class Main
     public function __construct()
     {
         $this->separator = str_repeat('-', 110) . PHP_EOL;
+    }
+
+
+    /**
+     * Set util class.
+     *
+     * @param Util $util Util class.
+     *
+     * @return void
+     */
+    private function setUtil(Util $util): void
+    {
+        $this->util = $util;
     }
 
 
@@ -195,7 +213,7 @@ class Main
         $php        = $this->options['php'];
         $phpcs      = $this->options['phpcs'];
         $warnings   = $this->options['warnings'];
-        $execString = Util::isWindows() === true ? "$phpcs --report=json --standard=$stndr $file $warnings" :
+        $execString = $this->util->isWindows() === true ? "$phpcs --report=json --standard=$stndr $file $warnings" :
             "$php $phpcs --report=json --standard=$stndr '$file' $warnings";
 
         $response = shell_exec($execString);

--- a/src/Main.php
+++ b/src/Main.php
@@ -80,7 +80,7 @@ class Main
      *
      * @return void
      */
-    private function setUtil(Util $util): void
+    public function setUtil(Util $util): void
     {
         $this->util = $util;
     }

--- a/src/Os.php
+++ b/src/Os.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SuperGiggle;
+
+class Os
+{
+
+    
+    /**
+     * Is the current platform windows?
+     *
+     * @return boolean
+     */
+    public function isWindows()
+    {
+        return (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
+    }
+
+
+}

--- a/src/Util.php
+++ b/src/Util.php
@@ -19,6 +19,11 @@ namespace SuperGiggle;
 class Util
 {
 
+    /**
+     * Os util
+     *
+     * @var Os
+     */
     private $os;
 
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -19,13 +19,15 @@ namespace SuperGiggle;
 class Util
 {
 
+    protected $os;
+
 
     /**
      * Parse args and return in a friendly format
      *
      * @return array
      */
-    public static function parseArgs(): array
+    public function parseArgs(): array
     {
         $alloweds = [
             'commit::',
@@ -55,7 +57,7 @@ class Util
      *
      * @return void
      */
-    public static function printUsage(): void
+    public function printUsage(): void
     {
         echo "  Usage: \033[0;35msuper-giggle [--commit]\033[0m\n\n";
         $options = [
@@ -85,11 +87,11 @@ class Util
      *
      * @return string
      */
-    public static function getPhpCsBinary(): string
+    public function getPhpCsBinary(): string
     {
         $path = __DIR__ . '/../vendor/bin/phpcs';
 
-        if (self::isWindows() === true) {
+        if ($this->os->isWindows() === true) {
             $path = str_replace('\\', '/', __DIR__ . '/../vendor/bin/phpcs.bat');
         }
 
@@ -98,13 +100,13 @@ class Util
 
 
     /**
-     * Checks the OS and returns true if Windows system is found.
+     * Set current operating system
      *
-     * @return boolean
+     * @return void
      */
-    public static function isWindows(): bool
+    public function setOs($os): void
     {
-        return (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
+        $this->os = $os;
     }
 
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -19,7 +19,7 @@ namespace SuperGiggle;
 class Util
 {
 
-    protected $os;
+    private $os;
 
 
     /**
@@ -100,11 +100,13 @@ class Util
 
 
     /**
-     * Set current operating system
+     * Set current operating system.
+     *
+     * @param Os $os Os class.
      *
      * @return void
      */
-    public function setOs($os): void
+    public function setOs(Os $os): void
     {
         $this->os = $os;
     }

--- a/tests/src/UtilTest.php
+++ b/tests/src/UtilTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SuperGiggle;
+
+use PHPUnit\Framework\TestCase;
+
+class UtilTest extends TestCase
+{
+
+
+    /**
+     * Define if the object can be constructed
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function objectCanBeConstructed()
+    {
+        $util = new Util();
+        $this->assertInstanceOf(Util::class, $util);
+    }
+
+
+    /**
+     * Test if directory is ok to windows platform
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function phpCsBinaryOnWindows()
+    {
+        $os = $this->createMock(Os::class);
+        $os->method('isWindows')
+           ->willReturn(true);
+
+        $util = new Util();
+        $util->setOs($os);
+
+        $this->assertStringContainsString('/../vendor/bin/phpcs.bat', $util->getPhpCsBinary());
+    }
+    
+
+    /**
+     * Test if directory is ok to linux platform
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function phpCsBinaryOnLinux()
+    {
+        $os = $this->createMock(Os::class);
+
+        $util = new Util();
+        $util->setOs($os);
+
+        $this->assertStringContainsString('/../vendor/bin/phpcs', $util->getPhpCsBinary());
+    }
+
+
+}


### PR DESCRIPTION
Hi, this PR adds phpunit to the tool.
I've added tests to `Util` class first (I'all send another PR to `Main` but i need to fix some windows compatibility issues first to send in the same PR)

### Running tests:
```bash
$ composer test
```

The command above run all tests in the `tests/` folder

### Changelog:
- Add Os class to centralize os related commands
- Changed `Util` to receive `Os` class to improve tests and maintenance
- Changed `Main` to receive `Util` class to improve tests and maintenance

Thanks for the great tool.